### PR TITLE
Refactor ci with parallel execution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Build Docker Image from External Repo
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,16 +2,17 @@ name: Build Docker Image from External Repo
 
 on:
   workflow_dispatch:
+  push:
   schedule:
     - cron: "0 0 * * *"
 
 jobs:
-  build-push:
-    name: Buid and push Docker image to GitHub Container registry
+  prepare:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    outputs:
+      latest_commit: ${{ steps.setup-vars.outputs.LATEST_COMMIT }}
+      latest_commit_short: ${{ steps.setup-vars.outputs.LATEST_COMMIT_SHORT }}
+      cache_hit: ${{ steps.cache-tdlib.outputs.cache-hit }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
@@ -40,25 +41,92 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           path: tdlib
 
+      - name: Setup variables
+        id: setup-vars
+        if: steps.cache-tdlib.outputs.cache-hit != 'true' || github.event_name!='schedule'
+        run: |
+          LATEST_COMMIT=${{fromJson(steps.get-tdlib-ref.outputs.data).commit.sha}}
+          LATEST_COMMIT_SHORT=${LATEST_COMMIT:0:7}
+          echo "LATEST_COMMIT=$LATEST_COMMIT" >> $GITHUB_OUTPUT
+          echo "LATEST_COMMIT_SHORT=$LATEST_COMMIT_SHORT" >> $GITHUB_OUTPUT
+          echo "## TDLib Build Information" >> $GITHUB_STEP_SUMMARY
+          echo "- Commit: [\`${{ fromJson(steps.get-tdlib-ref.outputs.data).commit.sha }}\`](https://github.com/tdlib/td/commit/${{ fromJson(steps.get-tdlib-ref.outputs.data).commit.sha }})" >> $GITHUB_STEP_SUMMARY
+          echo "- Short hash: \`${LATEST_COMMIT:0:7}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Cache hit: \`${{ steps.cache-tdlib.outputs.cache-hit }}\`" >> $GITHUB_STEP_SUMMARY
+
+  build:
+    needs: prepare
+    if: needs.prepare.outputs.cache_hit != 'true' || github.event_name!='schedule'
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
+        include:
+          - platform: amd64
+            runs-on: [ubuntu-latest]
+          - platform: arm64
+            runs-on: [ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runs-on }}
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
       - name: Login to GitHub Container registry
-        if: steps.cache-tdlib.outputs.cache-hit != 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set env vars
-        if: steps.cache-tdlib.outputs.cache-hit != 'true'
-        run: |
-          LATEST_COMMIT=${{fromJson(steps.get-tdlib-ref.outputs.data).commit.sha}}
-          LATEST_COMMIT_SHORT=${LATEST_COMMIT:0:7}
-          echo "LATEST_COMMIT=$LATEST_COMMIT" >> $GITHUB_ENV
-          echo "LATEST_COMMIT_SHORT=$LATEST_COMMIT_SHORT" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
-        if: steps.cache-tdlib.outputs.cache-hit != 'true'
+      - uses: docker/metadata-action@v5
+        id: metadata
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ needs.prepare.outputs.latest_commit_short }}-alpine-${{ matrix.platform }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          context: ${{ inputs.context }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-alpine-${{ matrix.platform }}
+          cache-to: |
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-alpine-${{ matrix.platform }},mode=max
+          build-args: |
+            TD_COMMIT=${{ needs.prepare.outputs.latest_commit }}
+
+  merge:
+    needs: [prepare, build]
+    if: needs.prepare.outputs.cache_hit != 'true' || github.event_name!='schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Login to GitHub Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
         run: |
-          tag=ghcr.io/${{ github.repository }}:${{ env.LATEST_COMMIT_SHORT }}-alpine
-          docker build --network host --build-arg TD_COMMIT=${{ env.LATEST_COMMIT }} --tag $tag .
-          docker push $tag
+          docker buildx imagetools create -t ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.latest_commit_short }}-alpine \
+            ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.latest_commit_short }}-alpine-amd64 \
+            ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.latest_commit_short }}-alpine-arm64
+
+      - name: Add image addresses to summary
+        run: |
+          echo "## Built Docker Images" >> $GITHUB_STEP_SUMMARY
+          echo "- Multi-arch image: \`ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.latest_commit_short }}-alpine\`" >> $GITHUB_STEP_SUMMARY
+          echo "- AMD64 image: \`ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.latest_commit_short }}-alpine-amd64\`" >> $GITHUB_STEP_SUMMARY
+          echo "- ARM64 image: \`ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.latest_commit_short }}-alpine-arm64\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,10 +97,11 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           context: ${{ inputs.context }}
-          cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-alpine-${{ matrix.platform }}
-          cache-to: |
-            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-alpine-${{ matrix.platform }},mode=max
+          # Uncomment the following lines to enable build caching while ci debugging
+          # cache-from: |
+          #   type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-alpine-${{ matrix.platform }}
+          # cache-to: |
+          #   type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-alpine-${{ matrix.platform }},mode=max
           build-args: |
             TD_COMMIT=${{ needs.prepare.outputs.latest_commit }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ RUN apk update && \
         linux-headers \
         openssl-dev \
         php \
-        zlib-dev && \
-    git clone "https://github.com/tdlib/td.git" /src && \
+        zlib-dev
+RUN git clone "https://github.com/tdlib/td.git" /src && \
     cd /src && \
     git checkout ${TD_COMMIT} && \
     rm -rf build && \
-    mkdir ./build && \
-    cd ./build && \
+    mkdir ./build
+RUN cd /src/build && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \

--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ This project uses GitHub's hosted runners for multi-architecture builds:
 - ARM64: Ubuntu 24.04 ARM runner (public preview)
 
 Note: ARM64 builds are only available for public repositories using GitHub's hosted runners.
+
+## Development
+
+### Build Caching for CI Debugging
+
+The GitHub Actions workflow (in .github/workflows/main.yml) has commented lines for build caching to increase speed if needed for development or CI debugging purposes, uncomment these lines if needed.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # tdlib-docker
+
+## CI/CD Information
+
+This project uses GitHub's hosted runners for multi-architecture builds:
+- AMD64: Standard Ubuntu runner
+- ARM64: Ubuntu 24.04 ARM runner (public preview)
+
+Note: ARM64 builds are only available for public repositories using GitHub's hosted runners.


### PR DESCRIPTION
This pull request updates the CI/CD pipeline and Dockerfile for the `tdlib-docker` project. The changes include restructuring the GitHub Actions workflow for building and pushing Docker images, as well as modifying the Dockerfile for improved build steps. Additionally, documentation has been added to the `README.md` file to provide information about the CI/CD process.

### CI/CD Pipeline Improvements:
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R4-R15): Restructured the workflow to include separate jobs for preparation, building, and merging. Added support for multi-architecture builds (amd64 and arm64) and improved caching and variable setup. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R4-R15) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R44-R132)

### Dockerfile Enhancements:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L19-R25): Split the RUN command to improve caching and build efficiency.

### Examples:
Build from scratch: https://github.com/keramblock/tdlib-docker/actions/runs/13071459788/attempts/1
Docker layers caching and summary output: https://github.com/keramblock/tdlib-docker/actions/runs/13073771334

### Things to double check
1. I didnt test results, as I do not have any working app with your library right now(but docker build of app is working fine, see logs below)
2. I split Dockerfile run command, to improve layers caching
3. I changed if to ease of development so "caching hit = true" will work only for scheduled builds
4. I used preview Github functions, as they are the only good variant I found(1hx2 instead of 8h of build time with emulator)

closes #1 